### PR TITLE
feat: support "Domain Reload" disabled in a project

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -408,6 +408,17 @@ namespace UniRx
         static bool initialized;
         static bool isQuitting = false;
 
+#if UNITY_2019_3_OR_NEWER && UNITY_EDITOR
+        // This callback is notified after assemblies have been loaded.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        private static void DomainCleanup()
+        {
+            instance = null;
+            initialized = false;
+            isQuitting = false;
+        }
+#endif
+
         public static string InstanceName
         {
             get

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs
@@ -74,6 +74,18 @@ namespace UniRx
             }
         }
 
+#if UNITY_2019_3_OR_NEWER && UNITY_EDITOR
+        // This callback is notified after assemblies have been loaded.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        private static void DomainCleanup()
+        {
+            mainThread = null;
+            mainThreadIgnoreTimeScale = null;
+            mainThreadEndOfFrame = null;
+            mainThreadFixedUpdate = null;
+        }
+#endif
+
         class MainThreadScheduler : IScheduler, ISchedulerPeriodic, ISchedulerQueueing
         {
             readonly Action<object> scheduleAction;

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ScenePlaybackDetector.cs
@@ -1,9 +1,11 @@
 #if UNITY_EDITOR
 
 using UnityEditor;
-using UnityEditor.Callbacks;
 using UnityEngine;
 
+#if !UNITY_2019_3_OR_NEWER
+using UnityEditor.Callbacks;
+#endif
 namespace UniRx
 {
     [InitializeOnLoad]
@@ -38,8 +40,13 @@ namespace UniRx
             }
         }
 
+#if UNITY_2019_3_OR_NEWER && UNITY_EDITOR
+        // This callback is notified after assemblies have been loaded.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+#else
         // This callback is notified after scripts have been reloaded.
         [DidReloadScripts]
+#endif
         public static void OnDidReloadScripts()
         {
             // Filter DidReloadScripts callbacks to the moment where playmodeState transitions into isPlaying.
@@ -54,9 +61,23 @@ namespace UniRx
         {
 #if UNITY_2017_2_OR_NEWER
             EditorApplication.playModeStateChanged += e =>
+            {
+                if (e == PlayModeStateChange.ExitingEditMode)
+                {
+                    AboutToStartScene = true;
+                }
+                else
+                {
+                    AboutToStartScene = false;
+                }
+
+                if (e == PlayModeStateChange.ExitingPlayMode)
+                {
+                    IsPlaying = false;
+                }
+            };
 #else
             EditorApplication.playmodeStateChanged += () =>
-#endif
             {
                 // Before scene start:          isPlayingOrWillChangePlaymode = false;  isPlaying = false
                 // Pressed Playback button:     isPlayingOrWillChangePlaymode = true;   isPlaying = false
@@ -77,6 +98,7 @@ namespace UniRx
                     IsPlaying = false;
                 }
             };
+#endif
         }
     }
 }


### PR DESCRIPTION
主要是3DReels Feature Team反應，TPFive專案關掉`Domain Reload`，UniRx再度進Play Mode就壞掉，所以他們都是在開啟`Domain Reload`的狀態開發